### PR TITLE
Fix typo - Button should be button

### DIFF
--- a/src/docs/basics/slow-start-guide.js
+++ b/src/docs/basics/slow-start-guide.js
@@ -71,10 +71,10 @@ export default {
 
     storiesOf('Button', module)
       .add('with text', () => (
-        <Button onClick={action('clicked')}>Hello Button</Button>
+        <button onClick={action('clicked')}>Hello Button</button>
       ))
       .add('with some emoji', () => (
-        <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>
+        <button onClick={action('clicked')}>😀 😎 👍 💯</button>
       ));
     ~~~
 


### PR DESCRIPTION
Users get an error when following the slow-start guide
https://github.com/kadirahq/react-storybook/issues/422