### PR TITLE
Fix typo in "default config" docs

### DIFF
--- a/src/docs/react-storybook/configurations/default-config.js
+++ b/src/docs/react-storybook/configurations/default-config.js
@@ -67,6 +67,6 @@ export default {
 
 
     > Unfortunately, we don't support Meteor packages. If your UI component includes one or more Meteor packages, try to avoid using them in UI components.
-    > If you are containers, you can use [React Stubber](https://github.com/kadirahq/react-stubber) to use them in Storybook.
+    > If they are containers, you can use [React Stubber](https://github.com/kadirahq/react-stubber) to use them in Storybook.
   `
 };


### PR DESCRIPTION
> If you are containers, you can use React Stubber (...)

->

> If they are containers, you can use React Stubber (...)