### PR TITLE
Update dependencies in slow-start-guide

### DIFF
--- a/src/docs/react-storybook/basics/slow-start-guide.js
+++ b/src/docs/react-storybook/basics/slow-start-guide.js
@@ -26,6 +26,13 @@ export default {
     npm i --save-dev @kadira/storybook
     ~~~
 
+    ## Add react and react-dom
+    Make sure that you have \`react\` and \`react-dom\` in your dependencies as well:
+
+    ~~~sh
+    npm i --save react react-dom
+    ~~~
+
     Then add the following NPM script to your package json in order to start the storybook later in this guide:
 
     ~~~js


### PR DESCRIPTION
Hi, I was following the "slow start guide" section in a "empty" project, I did everything in the docs, but when I ran `npm run storybook` I got a bunch of errors in my terminal, after a check the logs I realize that  was missing `react` and `react-dom` dependencies.
This commits adds a section for it.